### PR TITLE
Change id field to string

### DIFF
--- a/deduce_app.py
+++ b/deduce_app.py
@@ -42,7 +42,7 @@ payload_model = api.model(
         'patient_first_names': fields.String(example=example_data['patient_first_names'],
                                              description='Multiple names can be separated by white space'),
         'patient_surname': fields.String(example=example_data['patient_surname']),
-        'id': fields.Integer(example=example_data['id'], required=False),
+        'id': fields.String(example=example_data['id'], required=False),
         'dates': fields.Boolean(example=example_data['dates'], required=False, default=True)
     }
 )
@@ -50,7 +50,7 @@ payload_model = api.model(
 response_model = api.model(
     'response',
     {
-        'text': fields.String, 'id': fields.Integer(required=False)
+        'text': fields.String, 'id': fields.String(required=False)
     }
 )
 

--- a/test/data/multiple_texts.json
+++ b/test/data/multiple_texts.json
@@ -3,7 +3,7 @@
       "text": "Dit is stukje tekst met daarin de naam Jan Jansen. De patient J. Jansen (e: j.jnsen@email.com, t: 06-12345678) is 64 jaar oud en woonachtig in Utrecht. Hij werd op 10 oktober door arts Peter de Visser ontslagen van de kliniek van het UMCU.",
       "patient_first_names": "Jan",
       "patient_surname": "Jansen",
-      "id": 1234,
+      "id": "1234",
       "dates": false
     },
     {

--- a/test/data/single_text.json
+++ b/test/data/single_text.json
@@ -2,6 +2,6 @@
   "text": "Dit is stukje tekst met daarin de naam Jan Jansen. De patient J. Jansen (e: j.jnsen@email.com, t: 06-12345678) is 64 jaar oud en woonachtig in Utrecht. Hij werd op 10 oktober door arts Peter de Visser ontslagen van de kliniek van het UMCU.",
   "patient_first_names": "Jan",
   "patient_surname": "Jansen",
-  "id": 1234,
+  "id": "1234",
   "dates": false
 }

--- a/test/test_service.py
+++ b/test/test_service.py
@@ -12,7 +12,7 @@ def client():
 
 def test_deidentify_none(client):
 
-    example_data = {'text': None, 'id': 8345}
+    example_data = {'text': None, 'id': '8345'}
 
     response = client.post("/deidentify",
                            data=json.dumps(example_data),
@@ -52,6 +52,7 @@ def test_deidentify_date_default(client):
     output_data = response.get_json()
 
     assert output_data['text'] == "<DATUM-1> 2021"
+
 
 def test_deidentify_date_true(client):
     """


### PR DESCRIPTION
* Now only accepts (and returns) Strings as id. Makes more sense as ints can be string, but strings can't be int. 